### PR TITLE
fix(security): changed Path::canonicalize to clean_path

### DIFF
--- a/Back/src/database/handlers.rs
+++ b/Back/src/database/handlers.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::process::exit;
 
 use bcrypt::{hash, DEFAULT_COST};
@@ -12,6 +11,7 @@ use crate::database::schema::users::dsl::users;
 use crate::database::schema::users::name;
 use crate::database::Result;
 use crate::database::{PostgresPool, UserData};
+use crate::utils::files::clean_path::clean_path;
 use crate::utils::files::file_info::check_path_is_folder;
 
 use super::model::{NewUserMountPoint, UserMountPoint};
@@ -127,7 +127,7 @@ impl UserData {
     // }
 
     pub fn add_user_mount_point(&self, user: &User, path: &String) -> Result<UserMountPoint> {
-        let pathed_path = match fs::canonicalize(path)?.into_os_string().into_string() {
+        let pathed_path = match clean_path(path).into_os_string().into_string() {
             Ok(path) => path,
             Err(_) => return Err("Mount point could not be resolved into a string".into()),
         };

--- a/Back/src/utils/files/clean_path.rs
+++ b/Back/src/utils/files/clean_path.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+use path_clean::clean;
+
+pub fn clean_path(path: &String) -> PathBuf {
+    let mut selection: &str = &*path;
+    while selection.starts_with(".") {
+        selection = &selection[1..];
+    }
+    clean(selection)
+}

--- a/Back/src/utils/files/mod.rs
+++ b/Back/src/utils/files/mod.rs
@@ -1,2 +1,3 @@
 pub mod file_info;
 pub mod list_files;
+pub mod clean_path;

--- a/Back/src/utils/users/mod.rs
+++ b/Back/src/utils/users/mod.rs
@@ -1,6 +1,8 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use crate::database::{model::User, UserData};
+
+use super::files::clean_path::clean_path;
 
 #[must_use]
 pub struct VerifiedUserPath {
@@ -19,16 +21,13 @@ impl VerifiedUserPath {
 
 pub fn verifiy_user_path(db: &UserData, path: &String, user: User) -> Option<VerifiedUserPath> {
     let mnts = db.get_user_mounts_points(&user)?;
-    let canonical = match fs::canonicalize(path) {
-        Ok(result) => result,
-        Err(_) => return None,
-    };
+    let clean_path = clean_path(path);
     for mnt in mnts {
-        for ancestor in canonical.ancestors() {
+        for ancestor in clean_path.ancestors() {
             if ancestor == PathBuf::from(&mnt) {
                 return Some(VerifiedUserPath {
                     user,
-                    path: canonical,
+                    path: clean_path,
                 });
             };
         }


### PR DESCRIPTION
path canonicalize needed to use the real file system to check the path. path_clean only uses the string This allows us to check if a path is valid even if the file does not exists (useful for file creation)